### PR TITLE
Navigation.Extensions Patch

### DIFF
--- a/BassClefStudio.UWP.Navigation.Extensions/BassClefStudio.UWP.Navigation.Extensions.nuspec
+++ b/BassClefStudio.UWP.Navigation.Extensions/BassClefStudio.UWP.Navigation.Extensions.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.UWP.Navigation.Extensions</id>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <title>BassClefStudio.UWP.Navigation.Extensions</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>

--- a/BassClefStudio.UWP.Navigation.Extensions/BassClefStudio.UWP.Navigation.Extensions.nuspec
+++ b/BassClefStudio.UWP.Navigation.Extensions/BassClefStudio.UWP.Navigation.Extensions.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.UWP.Navigation.Extensions</id>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <title>BassClefStudio.UWP.Navigation.Extensions</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>

--- a/BassClefStudio.UWP.Navigation.Extensions/NavigationActivationHandler.cs
+++ b/BassClefStudio.UWP.Navigation.Extensions/NavigationActivationHandler.cs
@@ -9,7 +9,7 @@ using Windows.ApplicationModel.Activation;
 namespace BassClefStudio.UWP.Navigation.Extensions
 {
     /// <summary>
-    /// Represents a basic <see cref="IForegroundActivationHandler"/> that 
+    /// An abstract <see cref="IForegroundActivationHandler"/> that can provide an <see cref="INavigationHandler"/> to start navigation based on received <see cref="IActivatedEventArgs"/>.
     /// </summary>
     public abstract class NavigationActivationHandler<T> : IForegroundActivationHandler where T : IActivatedEventArgs
     {

--- a/BassClefStudio.UWP.Navigation.Extensions/NavigationServiceHandler.cs
+++ b/BassClefStudio.UWP.Navigation.Extensions/NavigationServiceHandler.cs
@@ -28,7 +28,7 @@ namespace BassClefStudio.UWP.Navigation.Extensions
         }
 
         /// <inheritdoc/>
-        public bool ActivateWindow(Lifecycle.Application app, Type pageType, object parameter, Type shellPageType = null)
+        public bool ActivateWindow(Lifecycle.Application app, Type pageType, object parameter = null, Type shellPageType = null)
         {
             Frame rootFrame = Window.Current.Content as Frame;
 
@@ -36,25 +36,23 @@ namespace BassClefStudio.UWP.Navigation.Extensions
             //// just ensure that the window is active
             if (rootFrame == null)
             {
-                //// Create a Frame to act as the navigation context and navigate to the first page
+                //// Create a Frame to act as the navigation context.
                 rootFrame = new Frame();
-
-                rootFrame.Content = new Frame();
-                NavigationService.Frame = rootFrame;
-
-                //// Navigate to the page...
-                if(shellPageType != null)
-                {
-                    NavigationService.Navigate(shellPageType);
-                }
-
-                NavigationService.Navigate(pageType, parameter);
             }
+
+            NavigationService.Frame = rootFrame;
 
             //// Ensure the current window is active, and then setup back navigation.
             Window.Current.Activate();
             app.InitializeBackNavigation();
 
+            //// Navigate to the page...
+            if (shellPageType != null)
+            {
+                NavigationService.Navigate(shellPageType);
+            }
+
+            NavigationService.Navigate(pageType, parameter);
             return true;
         }
 

--- a/BassClefStudio.UWP.Navigation.Extensions/NavigationServiceHandler.cs
+++ b/BassClefStudio.UWP.Navigation.Extensions/NavigationServiceHandler.cs
@@ -38,6 +38,7 @@ namespace BassClefStudio.UWP.Navigation.Extensions
             {
                 //// Create a Frame to act as the navigation context.
                 rootFrame = new Frame();
+                Window.Current.Content = rootFrame;
             }
 
             NavigationService.Frame = rootFrame;


### PR DESCRIPTION
This patch fixes an issue where a new `Frame` created for displaying activated window content was not set as the value of `Window.Current.Content`, and thus the app locked on the splash screen when the INavigationHandler was used. This is referenced in issue #23 .